### PR TITLE
Validating submission input parameters in quick launches

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,10 +16,11 @@
                  [org.cyverse/common-cfg "2.8.1"]
                  [org.cyverse/common-swagger-api "2.10.3-SNAPSHOT"]
                  [org.flatland/ordered "1.5.7"]
-                 [org.cyverse/service-logging "2.8.0"]
+                 [org.cyverse/service-logging "2.8.1"]
                  [me.raynes/fs "1.4.6"]
                  [ring "1.7.1"]
                  [cheshire "5.8.1"]
+                 [slingshot "0.12.2"]
                  [proto-repl "0.3.1"]]
   :eastwood {:exclude-namespaces [apps.protocols :test-paths]
              :linters [:wrong-arity :wrong-ns-form :wrong-pre-post :wrong-tag :misplaced-docstrings]}

--- a/src/analyses/clients.clj
+++ b/src/analyses/clients.clj
@@ -1,0 +1,92 @@
+(ns analyses.clients
+  (:require [analyses.config :refer [data-info-base-uri apps-base-uri]]
+            [clj-http.client :as http]
+            [cemerick.url :refer [url]]
+            [clojure-commons.error-codes :refer :all]
+            [slingshot.slingshot :refer [try+ throw+]]))
+
+(def public-user "public")
+
+(defn apps-url
+  ([components]
+   (apps-url components {}))
+  ([components username query]
+   (-> (apply url (apps-base-uri) components)
+       (assoc :query (assoc query :user username))
+       (str))))
+
+(defn data-info-url
+  ([components]
+   (data-info-url components {}))
+  ([components username query]
+   (-> (apply url (data-info-base-uri) components)
+       (assoc :query (assoc query :user username))
+       (str))))
+
+(defn get-path-info
+  [user & {:keys [paths ids] :as params}]
+  (when (or (seq paths) (seq ids))
+    (let [body-map   (select-keys (merge {:ids ids} {:paths paths}) [:ids :paths])
+          url-params (select-keys params [:validation-behavior
+                                          :filter-include
+                                          :filter-exclude])]
+      (:body (http/post (data-info-url ["path-info"] user url-params)
+                        {:content-type :json
+                         :as           :json
+                         :form-params  body-map})))))
+
+(defn paths-publicly-accessible
+  [paths]
+  (try+
+   (get-path-info public-user {:paths (if (sequential? paths) paths [paths])})
+   (catch [:status 500] e
+     (if (#{ERR_NOT_READABLE ERR_DOES_NOT_EXIST} (:error_code e))
+       false
+       (throw+)))))
+
+(defn get-app
+  [user system-id app-id]
+  (:body (http/get (apps-url ["apps" system-id app-id] user {}) {:as :json})))
+
+(def ^:private input-multiplicities
+  {"FileInput"         "single"
+   "FolderInput"       "collection"
+   "MultiFileSelector" "many"})
+
+(def ^:private input-types
+  (set (keys input-multiplicities)))
+
+(defn- input?
+  [{:keys [type]}]
+  (input-types type))
+
+(defn- validate-prop-value
+  [config {:keys [id] :as prop}]
+  (let [value (config (keyword id))]
+    (if (input? prop)
+      (if-not (paths-publicly-accessible value)
+        (throw+ {:error_code ERR_NOT_READABLE :user public-user :path value})))))
+
+(defn- validate-prop
+  [config prop]
+  (when (contains? config :id)
+    (validate-prop-value config prop)))
+
+(defn- validate-app-props
+  [config props]
+  (doseq [a-prop props]
+    (validate-prop config a-prop)))
+
+(defn- validate-app-group
+  [config group]
+  (doseq [app-props (get-in group [:parameters])]
+    (validate-app-props config app-props)))
+
+(defn- validate-app-groups
+  [config groups]
+  (doseq [a-group groups]
+    (validate-app-group config a-group)))
+
+(defn validate-submission
+  [submission app]
+  (validate-app-groups (:config submission) (:groups app)))

--- a/src/analyses/clients.clj
+++ b/src/analyses/clients.clj
@@ -12,7 +12,7 @@
    (apps-url components {}))
   ([components username query]
    (-> (apply url (apps-base-uri) components)
-       (assoc :query (assoc query :user username))
+       (assoc :query (assoc query :user (clojure.string/replace username "@iplantcollaborative.org" "")))
        (str))))
 
 (defn data-info-url

--- a/src/analyses/config.clj
+++ b/src/analyses/config.clj
@@ -66,6 +66,16 @@
   [props config-valid configs]
   "analyses.db.password" "notprod")
 
+(cc/defprop-optstr data-info-base-uri
+  "The base URI for the data-info service"
+  [props config-valid configs]
+  "analyses.data-info.base-uri" "http://data-info")
+
+(cc/defprop-optstr apps-base-uri
+  "The base URI for the apps service"
+  [props config-valid configs]
+  "analyses.apps.base-uri" "http://apps")
+
 (defn- validate-config
   "Validates the configuration settings after they've been loaded."
   []

--- a/src/analyses/controllers.clj
+++ b/src/analyses/controllers.clj
@@ -5,7 +5,7 @@
 (defn add-quicklaunch
   [user quicklaunch]
   (when (:is_public quicklaunch)
-    (clients/validate-submission (:submission quicklaunch) (clients/get-app (:app_id quicklaunch))))
+    (clients/validate-submission (:submission quicklaunch) (clients/get-app user "de" (:app_id quicklaunch))))
   (persist/add-quicklaunch user quicklaunch))
 
 (defn update-quicklaunch

--- a/src/analyses/controllers.clj
+++ b/src/analyses/controllers.clj
@@ -1,0 +1,19 @@
+(ns analyses.controllers
+  (:require [analyses.persistence :as persist]
+            [analyses.clients :as clients]))
+
+(defn add-quicklaunch
+  [user quicklaunch]
+  (when (:is_public quicklaunch)
+    (clients/validate-submission (:submission quicklaunch) (clients/get-app (:app_id quicklaunch))))
+  (persist/add-quicklaunch user quicklaunch))
+
+(defn update-quicklaunch
+  [id user quicklaunch]
+  (when (and (contains? quicklaunch :is_public)
+             (:is_public quicklaunch))
+    (let [app (clients/get-app user "de" (:app_id quicklaunch))]
+      (if (contains? quicklaunch :submission)
+        (clients/validate-submission (persist/merge-submission id user (:submission quicklaunch)) app)
+        (clients/validate-submission (persist/get-submission (:submission_id (persist/get-unjoined-quicklaunch id user))) app))))
+  (persist/update-quicklaunch id user quicklaunch))

--- a/src/analyses/controllers.clj
+++ b/src/analyses/controllers.clj
@@ -4,16 +4,13 @@
 
 (defn add-quicklaunch
   [user quicklaunch]
-  (when (:is_public quicklaunch)
-    (clients/validate-submission (:submission quicklaunch) (clients/get-app user "de" (:app_id quicklaunch))))
+  (clients/validate-submission (:submission quicklaunch) (clients/get-app user "de" (:app_id quicklaunch)))
   (persist/add-quicklaunch user quicklaunch))
 
 (defn update-quicklaunch
   [id user quicklaunch]
-  (when (and (contains? quicklaunch :is_public)
-             (:is_public quicklaunch))
-    (let [app (clients/get-app user "de" (:app_id quicklaunch))]
-      (if (contains? quicklaunch :submission)
-        (clients/validate-submission (persist/merge-submission id user (:submission quicklaunch)) app)
-        (clients/validate-submission (persist/get-submission (:submission_id (persist/get-unjoined-quicklaunch id user))) app))))
-  (persist/update-quicklaunch id user quicklaunch))
+  (let [app (clients/get-app user "de" (:app_id quicklaunch))]
+    (if (contains? quicklaunch :submission)
+      (clients/validate-submission (persist/merge-submission id user (:submission quicklaunch)) app)
+      (clients/validate-submission (persist/get-submission (:submission_id (persist/get-unjoined-quicklaunch id user))) app))
+    (persist/update-quicklaunch id user quicklaunch)))

--- a/src/analyses/persistence.clj
+++ b/src/analyses/persistence.clj
@@ -166,14 +166,14 @@
     (exec insert-sql)
     (get-quicklaunch new-uuid user)))
 
-(defn- get-unjoined-quicklaunch
+(defn get-unjoined-quicklaunch
   [id user]
   (first (query (-> (select :*)
                     (from :quick_launches)
                     (where [:= :id (uuidify id)]
                            [:= :creator (get-user user)])))))
 
-(defn- merge-submission
+(defn merge-submission
   [ql-id user new-submission]
   (when-let* [submission-id  (:submission_id (get-unjoined-quicklaunch ql-id user))
               old-submission (:submission (get-submission submission-id))]

--- a/src/analyses/routes.clj
+++ b/src/analyses/routes.clj
@@ -11,7 +11,8 @@
             [ring.util.http-response :refer [ok]]
             [ring.middleware.keyword-params :refer [wrap-keyword-params]]
             [service-logging.middleware :refer [log-validation-errors add-user-to-context]]
-            [analyses.persistence :as persist])
+            [analyses.persistence :as persist]
+            [analyses.controllers :as ctlr])
   (:import [java.util UUID]))
 
 (defapi app
@@ -48,7 +49,7 @@
         :description  "Adds a Quick Launch and corresponding submission information to the
         database. The username passed in should already exist. A new UUID will be
         assigned and returned."
-        (ok (coerce! QuickLaunch (persist/add-quicklaunch user ql))))
+        (ok (coerce! QuickLaunch (ctlr/add-quicklaunch user ql))))
 
       (GET "/" []
         :query       [{:keys [user]} StandardUserQueryParams]
@@ -89,7 +90,7 @@
           :summary      "Modifies an existing Quick Launch"
           :description  "Modifies an existing Quick Launch, allowing the caller to change
            owners and the contents of the submission JSON"
-          (ok (coerce! QuickLaunch (persist/update-quicklaunch id user uql))))
+          (ok (coerce! QuickLaunch (ctlr/update-quicklaunch id user uql))))
 
         (DELETE "/" []
           :query        [{:keys [user]} StandardUserQueryParams]


### PR DESCRIPTION
This should only apply for adding and updating quicklaunches. Paths are always validated, even if the quick launch is private.