### PR TITLE
CORE-1219: fix some schema validation errors.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
                  [org.cyverse/clojure-commons "3.0.5"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "3.0.7-SNAPSHOT"]
+                 [org.cyverse/common-swagger-api "3.0.7"]
                  [org.flatland/ordered "1.5.7"]
                  [org.cyverse/service-logging "2.8.2"]
                  [me.raynes/fs "1.4.6"]

--- a/project.clj
+++ b/project.clj
@@ -34,6 +34,6 @@
              :uberjar {:aot :all}}
   :main ^:skip-aot analyses.core
   :ring {:handler analyses.routes/app
-         :init analyses.core/load-config-from-file
+         :init analyses.core/init
          :port 31327}
   :repl-options {:init-ns analyses.core})

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
                  [org.cyverse/clojure-commons "3.0.5"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "3.0.1"]
+                 [org.cyverse/common-swagger-api "3.0.7-SNAPSHOT"]
                  [org.flatland/ordered "1.5.7"]
                  [org.cyverse/service-logging "2.8.2"]
                  [me.raynes/fs "1.4.6"]

--- a/src/analyses/config.clj
+++ b/src/analyses/config.clj
@@ -101,14 +101,6 @@
   (let [f (fs/file filename)]
     (when (.isFile f) (.getPath f))))
 
-(defn- classpath-file
-  [filename]
-  (-> (Thread/currentThread)
-      (.getContextClassLoader)
-      (.findResource filename)
-      (.toURI)
-      (fs/file)))
-
 (defn- no-configuration-found
   [filename]
   (throw (RuntimeException. (str "configuration file " filename " not found"))))
@@ -118,12 +110,9 @@
   (let [conf-file "analyses.properties"]
     (or (iplant-conf-dir-file conf-file)
         (cwd-file conf-file)
-        (classpath-file conf-file)
         (no-configuration-found conf-file))))
 
 (defn load-config-from-file
   "Loads the configuration settings from a properties file."
-  ([]
-   (load-config-from-file (find-config-file)))
-  ([cfg-path]
-   (load-and-validate-config-file cfg-path)))
+  [& [cfg-path]]
+  (load-and-validate-config-file (or cfg-path (find-config-file))))

--- a/src/analyses/core.clj
+++ b/src/analyses/core.clj
@@ -22,6 +22,10 @@
   (log/warn "Started listening on" (config/listen-port))
   ((eval 'ring.adapter.jetty/run-jetty) routes/app {:port (config/listen-port)}))
 
+(defn init [& [options]]
+  (config/load-config-from-file (:config options))
+  (common-persist/define-database))
+
 (defn -main
   [& args]
   (tc/with-logging-context config/svc-info
@@ -30,7 +34,6 @@
         (ccli/exit 1 (str "The config file does not exist.")))
       (when-not (fs/readable? (:config options))
         (ccli/exit 1 "The config file is not readable."))
-      (config/load-config-from-file (:config options))
-      (common-persist/define-database)
+      (init options)
       (http/with-connection-pool {:timeout 5 :threads 10 :insecure? false :default-per-route 10}
         (run-jetty)))))

--- a/src/analyses/persistence/settings.clj
+++ b/src/analyses/persistence/settings.clj
@@ -8,7 +8,7 @@
 (defn list-concurrent-job-limits
   "Lists all defined concurrent job limits."
   []
-  (as-> (h/select [:launcher :username] :concurrent_jobs) q
+  (as-> (h/select [:launcher :username] :concurrent_jobs [(sql/call := :launcher nil) :is_default]) q
     (h/from q :job_limits)
     (h/order-by q [:launcher :asc])
     (log-statement q)
@@ -17,9 +17,10 @@
 (defn- get-concurrent-job-limit*
   "Gets the concurrent job limit for a user."
   [tx username]
-  (as-> (h/select [:launcher :username] :concurrent-jobs) q
+  (as-> (h/select [:launcher :username] :concurrent_jobs [(sql/call := :launcher nil) :is_default]) q
     (h/from q :job_limits)
-    (h/where q [:= :launcher username])
+    (h/where q [:or [:= :launcher (sql/call :regexp_replace username "-" "_")] [:= :launcher nil]])
+    (h/order-by q :is_default)
     (sql/format q)
     (log/spy :debug q)
     (jdbc/query tx q)
@@ -31,16 +32,14 @@
    result will be nil."
   [username]
   (jdbc/with-db-transaction [tx (deref de)]
-    (->> (map (partial get-concurrent-job-limit* tx) [username nil])
-         (remove nil?)
-         first)))
+    (get-concurrent-job-limit* tx username)))
 
 (defn update-concurrent-job-limit*
   "Updates the concurrent job limit for a user."
   [tx username limit]
   (as-> (h/update :job_limits) q
     (h/sset q {:concurrent_jobs limit})
-    (h/where q [:= :launcher username])
+    (h/where q [:= :launcher (sql/call :regexp_replace username "-" "_")])
     (sql/format q)
     (log/spy :debug q)
     (jdbc/execute! tx q)))
@@ -49,7 +48,7 @@
   "Inserts a concurrent job limit for a user."
   [tx username limit]
   (as-> (h/insert-into :job_limits) q
-    (h/values q [{:launcher        username
+    (h/values q [{:launcher        (sql/call :regexp_replace username "-" "_")
                   :concurrent_jobs limit}])
     (sql/format q)
     (log/spy :debug q)
@@ -60,16 +59,16 @@
    if the requested limit is the same as the default limit."
   [username limit]
   (jdbc/with-db-transaction [tx (deref de)]
-    (if (get-concurrent-job-limit* tx username)
-      (update-concurrent-job-limit* tx username limit)
-      (insert-concurrent-job-limit* tx username limit))
+    (if (:is_default (get-concurrent-job-limit* tx username))
+      (insert-concurrent-job-limit* tx username limit)
+      (update-concurrent-job-limit* tx username limit))
     (get-concurrent-job-limit* tx username)))
 
 (defn- remove-concurrent-job-limit*
   "Removes the concurrent job limit for a user."
   [tx username]
   (as-> (h/delete-from :job_limits) q
-    (h/where q [:= :launcher username])
+    (h/where q [:= :launcher (sql/call :regexp_replace username "-" "_")])
     (sql/format q)
     (log/spy :debug q)
     (jdbc/execute! tx q)))


### PR DESCRIPTION
The `DELETE /settings/concurrent-job-limits/:username` endpoint was always returning a response body schema validation error. The `GET /settings/concurrent-job-limits/:username` endpoint was also returning the same error when the default limit was being used. This change fixes those problems and updates the response bodies to make it a bit easier to spot when the default setting is being used.
