### PR TITLE
Bump common-swagger-api to 3.0.8 for limitCheck changes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
                  [org.cyverse/clojure-commons "3.0.5"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "3.0.7"]
+                 [org.cyverse/common-swagger-api "3.0.8"]
                  [org.flatland/ordered "1.5.7"]
                  [org.cyverse/service-logging "2.8.2"]
                  [me.raynes/fs "1.4.6"]


### PR DESCRIPTION
I think this should fix the bug in the screenshot below, reported in slack:

![vice_500_error](https://user-images.githubusercontent.com/106004/109528422-e235c580-7a71-11eb-8ec1-ec0e1fdab125.png)
