### PR TITLE
CORE-316 Update quicklaunches endpoints to use app versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,6 @@ pom.xml.asc
 .eastwood
 .hgignore
 .hg/
+.idea
+*.iml
 analyses.properties

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
                  [org.cyverse/clojure-commons "3.0.5"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "3.0.10"]
+                 [org.cyverse/common-swagger-api "3.2.4-SNAPSHOT"]
                  [org.flatland/ordered "1.5.7"]
                  [org.cyverse/service-logging "2.8.2"]
                  [me.raynes/fs "1.4.6"]

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
                  [org.cyverse/clojure-commons "3.0.5"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "3.2.4-SNAPSHOT"]
+                 [org.cyverse/common-swagger-api "3.3.0"]
                  [org.flatland/ordered "1.5.7"]
                  [org.cyverse/service-logging "2.8.2"]
                  [me.raynes/fs "1.4.6"]

--- a/src/analyses/persistence.clj
+++ b/src/analyses/persistence.clj
@@ -167,6 +167,7 @@
   [update-map]
   (-> update-map
       (uuidify-entry [:app_id])
+      (uuidify-entry [:app_version_id])
       (uuidify-entry [:id])
       (uuidify-entry [:creator])
       (uuidify-entry [:submission_id])
@@ -188,7 +189,11 @@
           submission-id (add-submission (merge-submission id user (:submission ql)))
           update-map    (fix-uuids (merge {:submission_id submission-id
                                            :creator       user-id}
-                                          (select-keys ql [:name :description :app_id :is_public])))
+                                          (select-keys ql [:name
+                                                           :description
+                                                           :app_id
+                                                           :app_version_id
+                                                           :is_public])))
           update-sql    (-> (update :quick_launches)
                             (sset update-map)
                             (where [:= :id      (uuidify id)]

--- a/src/analyses/routes.clj
+++ b/src/analyses/routes.clj
@@ -5,7 +5,6 @@
         [analyses.schema])
   (:require [compojure.api.sweet :refer :all]
             [common-swagger-api.schema.apps :refer [AppIdParam AppJobView]]
-            [common-swagger-api.schema.analyses :refer [AnalysisSubmission]]
             [cheshire.core :as cheshire]
             [clojure-commons.exception :refer [exception-handlers]]
             [clojure-commons.lcase-params :refer [wrap-lcase-params]]
@@ -16,8 +15,7 @@
             [ring.middleware.keyword-params :refer [wrap-keyword-params]]
             [service-logging.middleware :refer [log-validation-errors add-user-to-context]]
             [analyses.persistence :as persist]
-            [analyses.controllers :as ctlr])
-  (:import [java.util UUID]))
+            [analyses.controllers :as ctlr]))
 
 (defn unrecognized-path-response
   "Builds the response to send for an unrecognized service path."


### PR DESCRIPTION
This PR will add `app_version_id` to `/quicklaunches` CRUD endpoint requests and responses.

PRs cyverse-de/de-database#10 and cyverse-de/common-swagger-api#75 must be merged first.