### PR TITLE
CORE-1695 Update quicklaunches app-info endpoint to use app versions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
                  [org.cyverse/clojure-commons "3.0.5"]
                  [org.cyverse/common-cli "2.8.1"]
                  [org.cyverse/common-cfg "2.8.1"]
-                 [org.cyverse/common-swagger-api "3.3.0"]
+                 [org.cyverse/common-swagger-api "3.4.0"]
                  [org.flatland/ordered "1.5.7"]
                  [org.cyverse/service-logging "2.8.2"]
                  [me.raynes/fs "1.4.6"]

--- a/src/analyses/clients.clj
+++ b/src/analyses/clients.clj
@@ -50,9 +50,13 @@
 
 (defn get-app
   [user system-id app-id]
-  (let [u (apps-url ["apps" system-id app-id] user {})]
-    (println u)
-    (:body (http/get (apps-url ["apps" system-id app-id] user {}) {:as :json}))))
+  (:body (http/get (apps-url ["apps" system-id app-id] user {})
+                   {:as :json})))
+
+(defn get-app-version
+  [user system-id app-id version-id]
+  (:body (http/get (apps-url ["apps" system-id app-id "versions" version-id] user {})
+                   {:as :json})))
 
 (def ^:private input-multiplicities
   {"FileInput"         "single"


### PR DESCRIPTION
This PR will update the `GET /quicklaunches/{id}/app-info` endpoint to lookup app info by specific app version.
It will also update the `/quicklaunches` add and update endpoints to lookup app info by specific app version.

Note that these changes require cyverse-de/apps#249 and cyverse-de/common-swagger-api#78