### PR TITLE
Remove the username suffix (if present) by simple regex rather than configuration.

### DIFF
--- a/src/analyses/clients.clj
+++ b/src/analyses/clients.clj
@@ -1,5 +1,5 @@
 (ns analyses.clients
-  (:require [analyses.config :refer [data-info-base-uri apps-base-uri username-suffix]]
+  (:require [analyses.config :refer [data-info-base-uri apps-base-uri]]
             [medley.core :as medley]
             [clj-http.client :as http]
             [cemerick.url :refer [url]]
@@ -11,13 +11,13 @@
 (defn apps-url
   [components username query]
   (-> (apply url (apps-base-uri) components)
-      (assoc :query (assoc query :user (clojure.string/replace username (username-suffix) "")))
+      (assoc :query (assoc query :user (clojure.string/replace username #"@.*$" "")))
       (str)))
 
 (defn data-info-url
   [components username query]
   (-> (apply url (data-info-base-uri) components)
-      (assoc :query (assoc query :user (clojure.string/replace username (username-suffix) "")))
+      (assoc :query (assoc query :user (clojure.string/replace username #"@.*$" "")))
       (str)))
 
 (defn get-path-info

--- a/src/analyses/config.clj
+++ b/src/analyses/config.clj
@@ -76,11 +76,6 @@
   [props config-valid configs]
   "analyses.apps.base-uri" "http://apps")
 
-(cc/defprop-str username-suffix
-  "The suffix appended to fully qualified usernames."
-  [props config-valid configs]
-  "analyses.username.suffix")
-
 (defn- validate-config
   "Validates the configuration settings after they've been loaded."
   []


### PR DESCRIPTION
As discussed in Slack recently, we can assume usernames will only have the `@` symbol as part of the legacy username suffix, and should only have one. This means that to get a username without the suffix, we don't need to know what the suffix actually is and can just replace `@.*$` with the empty string.