### PR TITLE
CORE-2074: removed time zone data mounts from the deployment definition

### DIFF
--- a/k8s/analyses.yml
+++ b/k8s/analyses.yml
@@ -19,24 +19,15 @@ spec:
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: de-app
-                operator: In
-                values:
-                - analyses
-            topologyKey: kubernetes.io/hostname
+            - labelSelector:
+                matchExpressions:
+                  - key: de-app
+                    operator: In
+                    values:
+                      - analyses
+              topologyKey: kubernetes.io/hostname
       restartPolicy: Always
       volumes:
-        - name: localtime
-          hostPath:
-            path: /etc/localtime
-        - name: timezone
-          configMap:
-            name: timezone
-            items:
-              - key: timezone
-                path: timezone
         - name: service-configs
           secret:
             secretName: service-configs
@@ -44,71 +35,70 @@ spec:
               - key: analyses.properties
                 path: analyses.properties
       containers:
-      - name: analyses
-        image: harbor.cyverse.org/de/analyses
-        args:
-          - --config
-          - /etc/iplant/de/analyses.properties
-        volumeMounts:
-          - name: localtime
-            mountPath: /etc/localtime
-            readOnly: true
-          - name: timezone
-            mountPath: /etc/timezone
-            subPath: timezone
-          - name: service-configs
-            mountPath: /etc/iplant/de
-            readOnly: true
-        resources:
-          requests:
-            cpu: "100m"
-            memory: "1Gi"
-            ephemeral-storage: "1Gi"
-          limits:
-            cpu: "3000m"
-            memory: "3Gi"
-            ephemeral-storage: "1Gi"
-        env:
-          - name: JAVA_TOOL_OPTIONS
-            valueFrom:
-              configMapKeyRef:
-                name: java-tool-options
-                key: high
-          - name: OTEL_TRACES_EXPORTER
-            valueFrom:
-              secretKeyRef:
-                name: configs
-                key: OTEL_TRACES_EXPORTER
-          - name: OTEL_EXPORTER_JAEGER_ENDPOINT
-            valueFrom:
-              secretKeyRef:
-                name: configs
-                key: OTEL_EXPORTER_JAEGER_ENDPOINT
-        ports:
-          - name: listen-port
-            containerPort: 60000
-        livenessProbe:
-          httpGet:
-            path: /
-            port: 60000
-          initialDelaySeconds: 60
-          periodSeconds: 20
-          timeoutSeconds: 10
-        startupProbe:
-          httpGet:
-            path: /
-            port: 60000
-          initialDelaySeconds: 60
-          periodSeconds: 20
-          timeoutSeconds: 10
-          failureThreshold: 30
-        readinessProbe:
-          httpGet:
-            path: /
-            port: 60000
-          initialDelaySeconds: 60
-          periodSeconds: 20
-          timeoutSeconds: 10
+        - name: analyses
+          image: harbor.cyverse.org/de/analyses
+          args:
+            - --config
+            - /etc/iplant/de/analyses.properties
+          volumeMounts:
+            - name: service-configs
+              mountPath: /etc/iplant/de
+              readOnly: true
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "1Gi"
+              ephemeral-storage: "1Gi"
+            limits:
+              cpu: "3000m"
+              memory: "3Gi"
+              ephemeral-storage: "1Gi"
+          env:
+            - name: TZ
+              valueFrom:
+                configMapKeyRef:
+                  name: timezone
+                  key: timezone
+            - name: JAVA_TOOL_OPTIONS
+              valueFrom:
+                configMapKeyRef:
+                  name: java-tool-options
+                  key: high
+            - name: OTEL_TRACES_EXPORTER
+              valueFrom:
+                secretKeyRef:
+                  name: configs
+                  key: OTEL_TRACES_EXPORTER
+            - name: OTEL_EXPORTER_JAEGER_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: configs
+                  key: OTEL_EXPORTER_JAEGER_ENDPOINT
+          ports:
+            - name: listen-port
+              containerPort: 60000
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 60000
+            initialDelaySeconds: 60
+            periodSeconds: 20
+            timeoutSeconds: 10
+          startupProbe:
+            httpGet:
+              path: /
+              port: 60000
+            initialDelaySeconds: 60
+            periodSeconds: 20
+            timeoutSeconds: 10
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 60000
+            initialDelaySeconds: 60
+            periodSeconds: 20
+            timeoutSeconds: 10
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
The relevant changes here are that I removed the time zone data mounts and added a `TZ` environment variable instead.